### PR TITLE
Replace 8 space with tab and add configure target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,25 +8,29 @@ PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)
 include $(INCLUDE_DIR)/package.mk
 
 define Package/sshpass
-        SECTION:=utils
-        CATEGORY:=Utilities
-        TITLE:=sshpass
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=sshpass
 endef
 
 define Package/sshpass/description
-        Sshpass is a tool for non-interactivly performing password authentication with SSH's
+	Sshpass is a tool for non-interactivly performing password authentication with SSH's
 endef
 
 #Specify what needs to be done to prepare for building the package.
 define Build/Prepare
-        mkdir -p $(PKG_BUILD_DIR)
-        $(CP) ./src/* $(PKG_BUILD_DIR)/
+	mkdir -p $(PKG_BUILD_DIR)
+	$(CP) ./src/* $(PKG_BUILD_DIR)/
+endef
+
+define Build/Configure
+	$(call Build/Configure/Default)
 endef
 
 #Specify where and how to install the program.
 define Package/sshpass/install
-        $(INSTALL_DIR) $(1)/bin
-        $(INSTALL_BIN) $(PKG_BUILD_DIR)/sshpass $(1)/bin/
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/sshpass $(1)/bin/
 endef
 
 #This line executes the necessary commands to compile our program.


### PR DESCRIPTION
The spaces had to be replaced by tabs for the `Makefile` to work and also the configure target was needed to invoke `./configure`
With this configuration the package built for me for 15.05.